### PR TITLE
Adjust gallery viewport height

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,4 +59,5 @@ If you are told to "release":
 <AGENT>
 - 2025-10-04: App scaffolded with Vite/React/TS. `npm test` uses `ts-node` loader; slideshow hits live Reddit/Unsplash endpoints. Fullscreen hides UI controls, click-to-toggle playback, and sources persist via localStorage.
 - 2025-10-04: Pace slider now uses exponential stops to 30m; playback controls live on the viewport overlay (center play, corner pause/fullscreen).
+- 2025-10-04: Gallery viewport sizing is tied to the window via flex `min-height: 0` adjustments; image fits stay constrained to the available stage.
 </AGENT>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Resize the gallery viewport with the window and ensure images scale to the available space. (#4)
+
 ## [0.1.0] - 2025-10-04
 
 - Scaffold the initial Vite + React TypeScript gallery experience with live Reddit and Unsplash sources.

--- a/src/App.css
+++ b/src/App.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  height: 100vh;
   background: linear-gradient(135deg, #101820, #1f1b2c);
   color: #f0f4f8;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -23,6 +24,7 @@
   gap: 2rem;
   padding: 2rem;
   box-sizing: border-box;
+  min-height: 0;
 }
 
 .app__sources {
@@ -37,6 +39,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  min-height: 0;
 }
 
 .source-form h2 {
@@ -135,6 +138,7 @@
   flex-direction: column;
   overflow: hidden;
   position: relative;
+  min-height: 0;
 }
 
 .gallery-viewport__stage {
@@ -145,6 +149,7 @@
   justify-content: center;
   background: #000;
   overflow: hidden;
+  min-height: 0;
 }
 
 .gallery-viewport__stage--fullscreen {


### PR DESCRIPTION
## Summary
- enforce flex min-height rules so the viewer tracks the window size
- keep the slideshow image constrained within the viewport stage

## Testing
- npm test

## Changelog
- Resize the gallery viewport with the window and ensure images scale to the available space. (#4)

Fixes #4