### PR TITLE
Add subreddit presets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,4 +60,5 @@ If you are told to "release":
 - 2025-10-04: App scaffolded with Vite/React/TS. `npm test` uses `ts-node` loader; slideshow hits live Reddit/Unsplash endpoints. Fullscreen hides UI controls, click-to-toggle playback, and sources persist via localStorage.
 - 2025-10-04: Pace slider now uses exponential stops to 30m; playback controls live on the viewport overlay (center play, corner pause/fullscreen).
 - 2025-10-04: Gallery viewport sizing is tied to the window via flex `min-height: 0` adjustments; image fits stay constrained to the available stage.
+- 2025-10-05: Reddit presets live in `SourcePresetCatalog.mts`; `handleAddPreset` skips duplicates and surfaces a message if everything already exists.
 </AGENT>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,4 +61,5 @@ If you are told to "release":
 - 2025-10-04: Pace slider now uses exponential stops to 30m; playback controls live on the viewport overlay (center play, corner pause/fullscreen).
 - 2025-10-04: Gallery viewport sizing is tied to the window via flex `min-height: 0` adjustments; image fits stay constrained to the available stage.
 - 2025-10-05: Reddit presets live in `SourcePresetCatalog.mts`; `handleAddPreset` skips duplicates and surfaces a message if everything already exists.
+- 2025-10-05: Source list now scrolls with a Clear-all button; preset form stays static to avoid nested scrolling.
 </AGENT>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,5 +61,5 @@ If you are told to "release":
 - 2025-10-04: Pace slider now uses exponential stops to 30m; playback controls live on the viewport overlay (center play, corner pause/fullscreen).
 - 2025-10-04: Gallery viewport sizing is tied to the window via flex `min-height: 0` adjustments; image fits stay constrained to the available stage.
 - 2025-10-05: Reddit presets live in `SourcePresetCatalog.mts`; `handleAddPreset` skips duplicates and surfaces a message if everything already exists.
-- 2025-10-05: Source list now scrolls with a Clear-all button; preset form stays static to avoid nested scrolling.
+- 2025-10-05: Source list now scrolls with a Clear-all button; preset form stays static to avoid nested scrolling, and a City preset highlights urban-focused subreddits.
 </AGENT>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add subreddit preset buttons for rapid source configuration, covering nature, synthetic, organic, aesthetic, and scholastic themes. (#3)
 - Resize the gallery viewport with the window and ensure images scale to the available space. (#4)
 
 ## [0.1.0] - 2025-10-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Add subreddit preset buttons for rapid source configuration, covering nature, synthetic, organic, aesthetic, and scholastic themes. (#3)
+ - Add subreddit preset buttons for rapid source configuration, covering nature, city, synthetic, organic, aesthetic, and scholastic themes. (#3)
 - Keep the preset form fixed, scroll added sources independently, and provide a Clear button to remove every source at once.
 - Resize the gallery viewport with the window and ensure images scale to the available space. (#4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Add subreddit preset buttons for rapid source configuration, covering nature, synthetic, organic, aesthetic, and scholastic themes. (#3)
+- Keep the preset form fixed, scroll added sources independently, and provide a Clear button to remove every source at once.
 - Resize the gallery viewport with the window and ensure images scale to the available space. (#4)
 
 ## [0.1.0] - 2025-10-04

--- a/src/App.css
+++ b/src/App.css
@@ -65,6 +65,42 @@
   border-radius: 8px;
 }
 
+.source-form__item--presets {
+  gap: 0.75rem;
+}
+
+.source-form__preset-heading {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.source-form__preset-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.source-form__preset-button {
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 999px;
+  background: rgba(63, 156, 255, 0.2);
+  color: #f0f4f8;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  font-weight: 600;
+}
+
+.source-form__preset-button:hover {
+  background: rgba(63, 156, 255, 0.35);
+}
+
+.source-form__preset-button:disabled {
+  background: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.5);
+  cursor: not-allowed;
+}
+
 .source-form__controls {
   display: flex;
   gap: 0.5rem;

--- a/src/App.css
+++ b/src/App.css
@@ -48,12 +48,9 @@
 }
 
 .source-form__scroll {
-  max-height: 240px;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding-right: 0.5rem;
 }
 
 .source-form__item {
@@ -132,12 +129,42 @@
 }
 
 .source-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.source-list__header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.source-list__clear {
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  background: rgba(255, 77, 109, 0.9);
+  color: white;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.source-list__clear:disabled {
+  background: rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.5);
+  cursor: not-allowed;
+}
+
+.source-list__items {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
 }
 
 .source-list__item {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ type OptionalImage = GalleryImage | undefined
 type GalleryAction =
   | { type: 'add-source'; entry: GallerySourceEntry }
   | { type: 'remove-source'; id: string }
+  | { type: 'clear-sources' }
   | { type: 'set-playing'; value: boolean }
   | { type: 'set-pace'; paceMs: number }
   | { type: 'set-image'; image: GalleryImage }
@@ -73,6 +74,18 @@ function galleryReducer(state: GalleryState, action: GalleryAction): GalleryStat
         ...state,
         entries: remaining,
         isPlaying: shouldStop ? false : state.isPlaying
+      }
+    }
+    case 'clear-sources': {
+      if (state.entries.length === 0) {
+        return state
+      }
+      return {
+        ...state,
+        entries: [],
+        currentImage: undefined,
+        isPlaying: false,
+        errorMessage: undefined
       }
     }
     case 'set-playing': {
@@ -186,6 +199,10 @@ export default function App(): JSX.Element {
     dispatch({ type: 'remove-source', id })
   }
 
+  const handleClearSources = () => {
+    dispatch({ type: 'clear-sources' })
+  }
+
   const handleTogglePlayback = () => {
     dispatch({ type: 'set-playing', value: !state.isPlaying })
   }
@@ -229,7 +246,7 @@ export default function App(): JSX.Element {
         {!isFullscreen && (
           <section className="app__sources">
             <SourceForm onAdd={handleAddSource} onAddPreset={handleAddPreset} isDisabled={state.isPlaying} />
-            <SourceList entries={state.entries} onRemove={handleRemoveSource} />
+            <SourceList entries={state.entries} onRemove={handleRemoveSource} onClear={handleClearSources} />
           </section>
         )}
         <section className="app__viewer">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import SourceForm from './components/SourceForm'
 import SourceList from './components/SourceList'
 import GalleryControls from './components/GalleryControls'
 import GalleryViewport from './components/GalleryViewport'
+import { SourcePresetEntry } from './lib/SourcePresetCatalog.mts'
 
 type OptionalImage = GalleryImage | undefined
 
@@ -156,6 +157,31 @@ export default function App(): JSX.Element {
     }
   }
 
+  const handleAddPreset = (entries: readonly SourcePresetEntry[]) => {
+    const existing = new Set(state.entries.map((entry) => entry.Describe()))
+    let added = false
+    for (const preset of entries) {
+      try {
+        const source = GallerySourceFactory.Create(preset.kind, preset.value)
+        const entry = GallerySourceEntry.Create(source)
+        const descriptor = entry.Describe()
+        if (existing.has(descriptor)) {
+          continue
+        }
+        existing.add(descriptor)
+        dispatch({ type: 'add-source', entry })
+        added = true
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        dispatch({ type: 'set-error', message })
+        return
+      }
+    }
+    if (!added) {
+      dispatch({ type: 'set-error', message: 'All preset sources already added.' })
+    }
+  }
+
   const handleRemoveSource = (id: string) => {
     dispatch({ type: 'remove-source', id })
   }
@@ -202,7 +228,7 @@ export default function App(): JSX.Element {
       <main className="app__main">
         {!isFullscreen && (
           <section className="app__sources">
-            <SourceForm onAdd={handleAddSource} isDisabled={state.isPlaying} />
+            <SourceForm onAdd={handleAddSource} onAddPreset={handleAddPreset} isDisabled={state.isPlaying} />
             <SourceList entries={state.entries} onRemove={handleRemoveSource} />
           </section>
         )}

--- a/src/components/SourceForm.tsx
+++ b/src/components/SourceForm.tsx
@@ -1,12 +1,16 @@
 import { FormEvent, useState, ChangeEvent } from 'react'
 import { GallerySourceKind } from '../lib/GallerySourceFactory.mts'
+import { SourcePresetCatalog, SourcePresetEntry } from '../lib/SourcePresetCatalog.mts'
 
 interface SourceFormProps {
   readonly onAdd: (kind: GallerySourceKind, value: string) => void
+  readonly onAddPreset: (entries: readonly SourcePresetEntry[]) => void
   readonly isDisabled: boolean
 }
 
-export default function SourceForm({ onAdd, isDisabled }: SourceFormProps): JSX.Element {
+const presetGroups = SourcePresetCatalog.All()
+
+export default function SourceForm({ onAdd, onAddPreset, isDisabled }: SourceFormProps): JSX.Element {
   const [redditValue, setRedditValue] = useState('')
   const [unsplashValue, setUnsplashValue] = useState('')
 
@@ -36,10 +40,34 @@ export default function SourceForm({ onAdd, isDisabled }: SourceFormProps): JSX.
     setUnsplashValue(event.target.value)
   }
 
+  const handlePresetAdd = (entries: readonly SourcePresetEntry[]) => {
+    if (isDisabled) {
+      return
+    }
+    onAddPreset(entries)
+  }
+
   return (
     <div className="source-form">
       <h2>Sources</h2>
       <div className="source-form__scroll">
+        <div className="source-form__item source-form__item--presets">
+          <h3 className="source-form__preset-heading">Presets</h3>
+          <div className="source-form__preset-list">
+            {presetGroups.map((group) => (
+              <button
+                key={group.label}
+                type="button"
+                className="source-form__preset-button"
+                onClick={() => handlePresetAdd(group.entries)}
+                disabled={isDisabled}
+                title={group.entries.map((entry) => entry.value).join(', ')}
+              >
+                {group.label}
+              </button>
+            ))}
+          </div>
+        </div>
         <form className="source-form__item" onSubmit={handleRedditSubmit}>
           <label htmlFor="reddit-input">Reddit Subreddit</label>
           <div className="source-form__controls">

--- a/src/components/SourceList.tsx
+++ b/src/components/SourceList.tsx
@@ -3,22 +3,34 @@ import { GallerySourceEntry } from '../lib/GallerySourceEntry.mts'
 interface SourceListProps {
   readonly entries: readonly GallerySourceEntry[]
   readonly onRemove: (id: string) => void
+  readonly onClear: () => void
 }
 
-export default function SourceList({ entries, onRemove }: SourceListProps): JSX.Element {
+export default function SourceList({ entries, onRemove, onClear }: SourceListProps): JSX.Element {
   if (entries.length === 0) {
-    return <p className="source-list__empty">No sources yet.</p>
+    return (
+      <div className="source-list">
+        <p className="source-list__empty">No sources yet.</p>
+      </div>
+    )
   }
   return (
-    <ul className="source-list">
-      {entries.map((entry) => (
-        <li key={entry.id} className="source-list__item">
-          <span>{entry.Describe()}</span>
-          <button type="button" onClick={() => onRemove(entry.id)}>
-            Remove
-          </button>
-        </li>
-      ))}
-    </ul>
+    <div className="source-list">
+      <div className="source-list__header">
+        <button type="button" className="source-list__clear" onClick={onClear}>
+          Clear
+        </button>
+      </div>
+      <ul className="source-list__items">
+        {entries.map((entry) => (
+          <li key={entry.id} className="source-list__item">
+            <span>{entry.Describe()}</span>
+            <button type="button" onClick={() => onRemove(entry.id)}>
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/src/lib/SourcePresetCatalog.mts
+++ b/src/lib/SourcePresetCatalog.mts
@@ -33,6 +33,15 @@ export class SourcePresetCatalog {
         'LavaPorn',
         'LakePorn'
       ]),
+      this.BuildRedditGroup('City', [
+        'CityPorn',
+        'ArchitecturePorn',
+        'SkylinePorn',
+        'Skyscrapers',
+        'UrbanPorn',
+        'UrbanExploration',
+        'AbandonedPorn'
+      ]),
       this.BuildRedditGroup('Synthetic', [
         'CityPorn',
         'VillagePorn',

--- a/src/lib/SourcePresetCatalog.mts
+++ b/src/lib/SourcePresetCatalog.mts
@@ -1,0 +1,152 @@
+import { GallerySourceKind } from './GallerySourceFactory.mts'
+
+export interface SourcePresetEntry {
+  readonly kind: GallerySourceKind
+  readonly value: string
+}
+
+export interface SourcePresetGroup {
+  readonly label: string
+  readonly entries: readonly SourcePresetEntry[]
+}
+
+export class SourcePresetCatalog {
+  public static All(): readonly SourcePresetGroup[] {
+    return [
+      this.BuildRedditGroup('Nature', [
+        'EarthPorn',
+        'BotanicalPorn',
+        'WaterPorn',
+        'SeaPorn',
+        'SkyPorn',
+        'FirePorn',
+        'DesertPorn',
+        'WinterPorn',
+        'AutumnPorn',
+        'WeatherPorn',
+        'GeologyPorn',
+        'SpacePorn',
+        'BeachPorn',
+        'MushroomPorn',
+        'SpringPorn',
+        'SummerPorn',
+        'LavaPorn',
+        'LakePorn'
+      ]),
+      this.BuildRedditGroup('Synthetic', [
+        'CityPorn',
+        'VillagePorn',
+        'RuralPorn',
+        'ArchitecturePorn',
+        'HousePorn',
+        'CabinPorn',
+        'ChurchPorn',
+        'AbandonedPorn',
+        'CemeteryPorn',
+        'InfrastructurePorn',
+        'MachinePorn',
+        'CarPorn',
+        'F1Porn',
+        'MotorcyclePorn',
+        'MilitaryPorn',
+        'GunPorn',
+        'KnifePorn',
+        'BoatPorn',
+        'RidesPorn',
+        'DestructionPorn',
+        'ThingsCutInHalfPorn',
+        'StarshipPorn',
+        'ToolPorn',
+        'TechnologyPorn',
+        'BridgePorn',
+        'PolicePorn',
+        'SteamPorn',
+        'RetailPorn',
+        'SpaceFlightPorn',
+        'RoadPorn',
+        'DryDockPorn'
+      ]),
+      this.BuildRedditGroup('Organic', [
+        'AnimalPorn',
+        'HumanPorn',
+        'EarthlingPorn',
+        'AdrenalinePorn',
+        'ClimbingPorn',
+        'SportsPorn',
+        'AgriculturePorn',
+        'TeaPorn',
+        'BonsaiPorn',
+        'FoodPorn',
+        'CulinaryPorn',
+        'DessertPorn'
+      ]),
+      this.BuildRedditGroup('Aesthetic', [
+        'DesignPorn',
+        'RoomPorn',
+        'AlbumArtPorn',
+        'MetalPorn',
+        'MoviePosterPorn',
+        'TelevisionPosterPorn',
+        'ComicBookPorn',
+        'StreetArtPorn',
+        'AdPorn',
+        'ArtPorn',
+        'FractalPorn',
+        'InstrumentPorn',
+        'ExposurePorn',
+        'MacroPorn',
+        'MicroPorn',
+        'GeekPorn',
+        'MTGPorn',
+        'GamerPorn',
+        'PowerWashingPorn',
+        'AerialPorn',
+        'OrganizationPorn',
+        'FashionPorn',
+        'AVPorn',
+        'ApocalypsePorn',
+        'InfraredPorn',
+        'ViewPorn',
+        'HellscapePorn',
+        'SculpturePorn'
+      ]),
+      this.BuildRedditGroup('Scholastic', [
+        'HistoryPorn',
+        'UniformPorn',
+        'BookPorn',
+        'NewsPorn',
+        'QuotesPorn',
+        'FuturePorn',
+        'FossilPorn',
+        'MegalithPorn',
+        'ArtefactPorn'
+      ])
+    ]
+  }
+
+  private static BuildRedditGroup(label: string, subreddits: readonly string[]): SourcePresetGroup {
+    const unique = new Map<string, SourcePresetEntry>()
+    for (const subreddit of subreddits) {
+      const trimmed = subreddit.trim()
+      if (trimmed.length === 0) {
+        continue
+      }
+      const key = trimmed.toLowerCase()
+      if (unique.has(key)) {
+        continue
+      }
+      unique.set(key, this.CreateEntry('reddit', trimmed))
+    }
+    return {
+      label,
+      entries: Array.from(unique.values())
+    }
+  }
+
+  private static CreateEntry(kind: GallerySourceKind, value: string): SourcePresetEntry {
+    return {
+      kind,
+      value
+    }
+  }
+}

--- a/test/SourcePresetCatalog.test.mts
+++ b/test/SourcePresetCatalog.test.mts
@@ -27,6 +27,18 @@ const expectedGroups = [
     ]
   },
   {
+    label: 'City',
+    values: [
+      'CityPorn',
+      'ArchitecturePorn',
+      'SkylinePorn',
+      'Skyscrapers',
+      'UrbanPorn',
+      'UrbanExploration',
+      'AbandonedPorn'
+    ]
+  },
+  {
     label: 'Synthetic',
     values: [
       'CityPorn',

--- a/test/SourcePresetCatalog.test.mts
+++ b/test/SourcePresetCatalog.test.mts
@@ -1,0 +1,151 @@
+import { test } from 'node:test'
+import { strict as assert } from 'node:assert'
+import { SourcePresetCatalog } from '../src/lib/SourcePresetCatalog.mts'
+
+const expectedGroups = [
+  {
+    label: 'Nature',
+    values: [
+      'EarthPorn',
+      'BotanicalPorn',
+      'WaterPorn',
+      'SeaPorn',
+      'SkyPorn',
+      'FirePorn',
+      'DesertPorn',
+      'WinterPorn',
+      'AutumnPorn',
+      'WeatherPorn',
+      'GeologyPorn',
+      'SpacePorn',
+      'BeachPorn',
+      'MushroomPorn',
+      'SpringPorn',
+      'SummerPorn',
+      'LavaPorn',
+      'LakePorn'
+    ]
+  },
+  {
+    label: 'Synthetic',
+    values: [
+      'CityPorn',
+      'VillagePorn',
+      'RuralPorn',
+      'ArchitecturePorn',
+      'HousePorn',
+      'CabinPorn',
+      'ChurchPorn',
+      'AbandonedPorn',
+      'CemeteryPorn',
+      'InfrastructurePorn',
+      'MachinePorn',
+      'CarPorn',
+      'F1Porn',
+      'MotorcyclePorn',
+      'MilitaryPorn',
+      'GunPorn',
+      'KnifePorn',
+      'BoatPorn',
+      'RidesPorn',
+      'DestructionPorn',
+      'ThingsCutInHalfPorn',
+      'StarshipPorn',
+      'ToolPorn',
+      'TechnologyPorn',
+      'BridgePorn',
+      'PolicePorn',
+      'SteamPorn',
+      'RetailPorn',
+      'SpaceFlightPorn',
+      'RoadPorn',
+      'DryDockPorn'
+    ]
+  },
+  {
+    label: 'Organic',
+    values: [
+      'AnimalPorn',
+      'HumanPorn',
+      'EarthlingPorn',
+      'AdrenalinePorn',
+      'ClimbingPorn',
+      'SportsPorn',
+      'AgriculturePorn',
+      'TeaPorn',
+      'BonsaiPorn',
+      'FoodPorn',
+      'CulinaryPorn',
+      'DessertPorn'
+    ]
+  },
+  {
+    label: 'Aesthetic',
+    values: [
+      'DesignPorn',
+      'RoomPorn',
+      'AlbumArtPorn',
+      'MetalPorn',
+      'MoviePosterPorn',
+      'TelevisionPosterPorn',
+      'ComicBookPorn',
+      'StreetArtPorn',
+      'AdPorn',
+      'ArtPorn',
+      'FractalPorn',
+      'InstrumentPorn',
+      'ExposurePorn',
+      'MacroPorn',
+      'MicroPorn',
+      'GeekPorn',
+      'MTGPorn',
+      'GamerPorn',
+      'PowerWashingPorn',
+      'AerialPorn',
+      'OrganizationPorn',
+      'FashionPorn',
+      'AVPorn',
+      'ApocalypsePorn',
+      'InfraredPorn',
+      'ViewPorn',
+      'HellscapePorn',
+      'SculpturePorn'
+    ]
+  },
+  {
+    label: 'Scholastic',
+    values: [
+      'HistoryPorn',
+      'UniformPorn',
+      'BookPorn',
+      'NewsPorn',
+      'QuotesPorn',
+      'FuturePorn',
+      'FossilPorn',
+      'MegalithPorn',
+      'ArtefactPorn'
+    ]
+  }
+]
+
+test('preset catalog contains expected groups without duplicates', () => {
+  const groups = SourcePresetCatalog.All()
+  assert.equal(groups.length, expectedGroups.length)
+
+  for (const expected of expectedGroups) {
+    const group = groups.find((candidate) => candidate.label === expected.label)
+    assert.ok(group, `missing preset group ${expected.label}`)
+    const seen = new Set<string>()
+    for (const entry of group.entries) {
+      assert.equal(entry.kind, 'reddit')
+      const normalized = entry.value.toLowerCase()
+      assert.ok(!seen.has(normalized), `duplicate subreddit ${entry.value} in ${group.label}`)
+      seen.add(normalized)
+    }
+    for (const value of expected.values) {
+      const found = group.entries.some((entry) => entry.value === value)
+      assert.ok(found, `missing subreddit ${value} in ${group.label}`)
+    }
+    assert.equal(group.entries.length, expected.values.length)
+  }
+})


### PR DESCRIPTION
## Summary
- add curated subreddit presets via SourcePresetCatalog
- expose preset buttons in the source form without scrolling the inputs
- introduce a City preset focused on urban and architectural subreddits
- let added sources scroll with a Clear button and wire clear-all handling

## Testing
- npm test

## Changelog
- Add subreddit preset buttons for rapid source configuration, covering nature, city, synthetic, organic, aesthetic, and scholastic themes. (#3)
- Keep the preset form fixed, scroll added sources independently, and provide a Clear button to remove every source at once.

Fixes #3
