### PR TITLE
Add keyboard navigation shortcuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,4 +63,5 @@ If you are told to "release":
 - 2025-10-05: Reddit presets live in `SourcePresetCatalog.mts`; `handleAddPreset` skips duplicates and surfaces a message if everything already exists.
 - 2025-10-05: Source list now scrolls with a Clear-all button; preset form stays static to avoid nested scrolling, and a City preset highlights urban-focused subreddits.
 - 2025-10-05: Fullscreen chrome auto-hides after idle, `f` toggles fullscreen, pace persists via `PacePersistence`, and Unsplash inputs require `?unsplash=on`.
+- 2025-10-05: Arrow keys walk slideshow history (with timer resets) and space toggles playback; `GalleryImagePicker` centralizes random fetches.
 </AGENT>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Keep the preset form fixed, scroll added sources independently, and provide a Clear button to remove every source at once.
 - Resize the gallery viewport with the window and ensure images scale to the available space. (#4)
 - Persist slideshow pace, hide fullscreen chrome after idle with an 'f' shortcut, and require `unsplash=on` to reveal Unsplash inputs. (#7)
+- Enable keyboard navigation so the space bar toggles playback while the left and right arrows step the slideshow and reset its timer. (#12)
 
 ## [0.1.0] - 2025-10-04
 

--- a/src/lib/GalleryImagePicker.mts
+++ b/src/lib/GalleryImagePicker.mts
@@ -1,0 +1,13 @@
+import { GalleryImage } from './GalleryImage.mts'
+import { GallerySourceEntry } from './GallerySourceEntry.mts'
+import { CHECK } from './Assertions.mts'
+import { GET_RANDOM_ITEM } from './Random.mts'
+
+export class GalleryImagePicker {
+  public static async FetchRandom(entries: readonly GallerySourceEntry[]): Promise<GalleryImage> {
+    CHECK(entries.length > 0, 'GalleryImagePicker requires at least one source entry')
+    const entry = GET_RANDOM_ITEM(entries)
+    const candidate = entry.source.FetchImage()
+    return candidate
+  }
+}


### PR DESCRIPTION
Summary
- add slideshow history so manual skips can move backward/forward
- wire keyboard shortcuts to play/pause and step the gallery while resetting the timer

Testing
- npm test

Changelog
- Enable keyboard navigation so the space bar toggles playback while the left and right arrows step the slideshow and reset its timer. (#12)

Resolves #12